### PR TITLE
Potion generation strategic

### DIFF
--- a/Assets/Scripts/PlayerCollision.cs
+++ b/Assets/Scripts/PlayerCollision.cs
@@ -23,13 +23,6 @@ public class PlayerCollision : MonoBehaviour
     public AudioClip potion_hit;
 
     void Start() {
-        // Set the active player to player 2 for now for transform of spawn to work
-        if (character1.activeSelf)
-            transform.parent.gameObject.GetComponent<Spawn>().setActivePlayer(character1);
-        else if (character2.activeSelf)
-            transform.parent.gameObject.GetComponent<Spawn>().setActivePlayer(character2);
-        else if (character3.activeSelf)
-            transform.parent.gameObject.GetComponent<Spawn>().setActivePlayer(character3);
         hitFinishLine = false;
         inHallway = false;
     }
@@ -74,21 +67,17 @@ public class PlayerCollision : MonoBehaviour
                 character1.transform.rotation = character2.transform.rotation;
                 character2.SetActive(false);
                 character1.SetActive(true);
-                transform.parent.gameObject.GetComponent<Spawn>().setActivePlayer(character1);
-                transform.parent.gameObject.GetComponent<Spawn>().setActivePotion(2);
                 camera.GetComponent<CameraController>().PlayerTransform = character1.transform.Find("Focus");
-        
+
             } else if (character3.activeSelf) {
                 print("Changing to character 1");
                 character1.transform.position = character3.transform.position;
                 character1.transform.rotation = character3.transform.rotation;
                 character3.SetActive(false);
                 character1.SetActive(true);
-                transform.parent.gameObject.GetComponent<Spawn>().setActivePlayer(character1);
-                transform.parent.gameObject.GetComponent<Spawn>().setActivePotion(2);
                 camera.GetComponent<CameraController>().PlayerTransform = character1.transform.Find("Focus");
             }
-    
+
         } else if (collision.collider.CompareTag("HumanPotion")) {
             collision.collider.gameObject.GetComponent<potionCollision>().Explode();
             GetComponent<AudioSource>().clip = potion_hit;
@@ -102,21 +91,17 @@ public class PlayerCollision : MonoBehaviour
                 character2.transform.rotation = character1.transform.rotation;
                 character1.SetActive(false);
                 character2.SetActive(true);
-                transform.parent.gameObject.GetComponent<Spawn>().setActivePlayer(character2);
-                transform.parent.gameObject.GetComponent<Spawn>().setActivePotion(0);
                 camera.GetComponent<CameraController>().PlayerTransform = character2.transform.Find("Focus");
-        
+
             } else if (character3.activeSelf) {
                 print("Changing to character 2");
                 character2.transform.position = character3.transform.position;
                 character2.transform.rotation = character3.transform.rotation;
                 character3.SetActive(false);
                 character2.SetActive(true);
-                transform.parent.gameObject.GetComponent<Spawn>().setActivePlayer(character2);
-                transform.parent.gameObject.GetComponent<Spawn>().setActivePotion(0);
                 camera.GetComponent<CameraController>().PlayerTransform = character2.transform.Find("Focus");
             }
-        
+
         } else if (collision.collider.CompareTag("DragonPotion")) {
             collision.collider.gameObject.GetComponent<potionCollision>().Explode();
             GetComponent<AudioSource>().clip = potion_hit;
@@ -128,24 +113,19 @@ public class PlayerCollision : MonoBehaviour
                 character3.transform.rotation = character2.transform.rotation;
                 character2.SetActive(false);
                 character3.SetActive(true);
-                transform.parent.gameObject.GetComponent<Spawn>().setActivePlayer(character3);
-                transform.parent.gameObject.GetComponent<Spawn>().setActivePotion(1);
                 camera.GetComponent<CameraController>().PlayerTransform = character3.transform.Find("Focus");
-        
+
             } else if (character1.activeSelf) {
                 print("Changing to character 3");
                 character3.transform.position = character1.transform.position;
                 character3.transform.rotation = character1.transform.rotation;
                 character1.SetActive(false);
                 character3.SetActive(true);
-                transform.parent.gameObject.GetComponent<Spawn>().setActivePlayer(character3);
-                transform.parent.gameObject.GetComponent<Spawn>().setActivePotion(1);
                 camera.GetComponent<CameraController>().PlayerTransform = character3.transform.Find("Focus");
             }
         }
         else if (collision.collider.CompareTag("PowerUp")) {
-
-            collision.collider.gameObject.GetComponent<potionCollision>().Explode();
+            Destroy(collision.collider.gameObject);
             GetComponent<AudioSource>().clip = gem_collect;
             GetComponent<AudioSource>().Play();
 

--- a/Assets/Scripts/PotionGenerator.cs
+++ b/Assets/Scripts/PotionGenerator.cs
@@ -15,6 +15,8 @@ public class PotionGenerator : MonoBehaviour
     {
       position = new Vector3(0f, 2f, 0f);
       position += gameObject.transform.position;
+      var potion = Instantiate(activePotion, position, Quaternion.identity);
+      potion.transform.parent = gameObject.transform;
     }
 
     // Call coroutine to generate a potion on this platform

--- a/Assets/Scripts/PotionGenerator.cs
+++ b/Assets/Scripts/PotionGenerator.cs
@@ -15,11 +15,10 @@ public class PotionGenerator : MonoBehaviour
     {
       position = new Vector3(0f, 2f, 0f);
       position += gameObject.transform.position;
-      generate();
     }
 
     // Call coroutine to generate a potion on this platform
-    void generate()
+    public void generate()
     {
       StartCoroutine(spawn());
     }

--- a/Assets/Scripts/PotionGenerator.cs
+++ b/Assets/Scripts/PotionGenerator.cs
@@ -3,15 +3,19 @@ using System.Collections.Generic;
 using UnityEngine;
 
 // This gets attached to a potion generation platform
-public class generatePotion : MonoBehaviour
+public class PotionGenerator : MonoBehaviour
 {
-    private bool hasPotion; // This platform has a potion
+    private Vector3 position;
+
     public float timeToSpawn; // Time before potion spawns again
+    public GameObject activePotion; // The potion to generate on this spot
 
     // Start is called before the first frame update
     void Start()
     {
-      hasPotion = true;
+      position = new Vector3(0f, 2f, 0f);
+      position += gameObject.transform.position;
+      generate();
     }
 
     // Call coroutine to generate a potion on this platform
@@ -24,10 +28,12 @@ public class generatePotion : MonoBehaviour
     IEnumerator spawn()
     {
       yield return new WaitForSeconds(timeToSpawn);
+
       // Instantiate new object as child of platform
-      // For now, we will just generate dragon potions
-      // Add other potions later
-      //Instantiate()
+      var potion = Instantiate(activePotion,
+                               position,
+                               Quaternion.identity);
+      potion.transform.parent = gameObject.transform;
     }
 
 }

--- a/Assets/Scripts/PotionGenerator.cs.meta
+++ b/Assets/Scripts/PotionGenerator.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 55f62fd282e626b4c93637c7d92cae71
+guid: a44d6b6547463d64f80eacf6d4cd91a5
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/Scripts/generatePotion.cs
+++ b/Assets/Scripts/generatePotion.cs
@@ -1,0 +1,33 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+// This gets attached to a potion generation platform
+public class generatePotion : MonoBehaviour
+{
+    private bool hasPotion; // This platform has a potion
+    public float timeToSpawn; // Time before potion spawns again
+
+    // Start is called before the first frame update
+    void Start()
+    {
+      hasPotion = true;
+    }
+
+    // Call coroutine to generate a potion on this platform
+    void generate()
+    {
+      StartCoroutine(spawn());
+    }
+
+    // Wait timeToSpawn seconds before spawning potion
+    IEnumerator spawn()
+    {
+      yield return new WaitForSeconds(timeToSpawn);
+      // Instantiate new object as child of platform
+      // For now, we will just generate dragon potions
+      // Add other potions later
+      //Instantiate()
+    }
+
+}

--- a/Assets/Scripts/generatePotion.cs.meta
+++ b/Assets/Scripts/generatePotion.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 55f62fd282e626b4c93637c7d92cae71
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/potionCollision.cs
+++ b/Assets/Scripts/potionCollision.cs
@@ -21,6 +21,7 @@ public class potionCollision : MonoBehaviour
     GameObject effect = Instantiate(particleEffect,
       transform.position,
       Quaternion.identity);
+    gameObject.transform.parent.GetComponent<PotionGenerator>().generate();
     Destroy(gameObject);
   }
 }


### PR DESCRIPTION
removed the particle effects from the time collectibles and changed the entire way of potion generation so they spawn in strategic locations. I've introduced what I called "platforms" that will generate potions that you can run to and pick up. The potions will all be available in the beginning of the game, and they will reappear 5 seconds after you consume them. I really think this is important to do because every pro we had in the last playtest as well as Steve in lecture told us to do this.